### PR TITLE
Removing dead link to WishThereWas repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,6 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
 * [web-dev-resources](https://github.com/ericandrewlewis/web-dev-resources) – A table of contents for web developer resources across the internet.
 * [web-development-resources](https://github.com/MasonONeal/web-development-resources)
 * [weekly](https://github.com/zenany/weekly) *In Chinese* – Weekly summary of articles and resources.
-* [WishThereWas](https://github.com/zavelevsky/WishThereWas) – An open source project wishlist.
 * [Worth-Reading-the-Android-technical-articles](https://github.com/zmywly8866/Worth-Reading-the-Android-technical-articles) *In Chinese*
 
 ### awesome-*


### PR DESCRIPTION
The original repository doesn't exist anywhere on Github, the user has probably taken it down