### PR TITLE
Add awesome-building-blocks-for-web-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
 * [awesome-browserify](https://github.com/browserify/awesome-browserify) – [Browserify](http://browserify.org/) bundler
 * [awesome-btcdev](https://github.com/btcbrdev/awesome-btcdev) – Bitcoin development
 * [awesome-bugs](https://github.com/criswell/awesome-bugs) – Funny and interesting bugs
+* [awesome-building-blocks-for-web-apps](https://github.com/componently-com/awesome-building-blocks-for-web-apps) - Standalone features to be integrated into web applications.
 * [awesome-c](https://github.com/aleksandar-todorovic/awesome-c) by @aleksandar-todorovic – Continuing the development of awesome-c on GitHub
 * [awesome-c](https://github.com/kozross/awesome-c) by @kozross – C frameworks, libraries, resources etc.
   - [mirror](https://notabug.org/koz.ross/awesome-c)

--- a/README.md
+++ b/README.md
@@ -562,7 +562,8 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
 * [awesome-browserify](https://github.com/browserify/awesome-browserify) – [Browserify](http://browserify.org/) bundler
 * [awesome-btcdev](https://github.com/btcbrdev/awesome-btcdev) – Bitcoin development
 * [awesome-bugs](https://github.com/criswell/awesome-bugs) – Funny and interesting bugs
-* [awesome-building-blocks-for-web-apps](https://github.com/componently-com/awesome-building-blocks-for-web-apps) - Standalone features to be integrated into web applications.
+* [awesome-building-blocks-for-web-apps](https://github.com/componently-com/awesome-building-blocks-for-web-apps) - Standalone features (services, components, libraries) to be integrated into web applications.
+  - https://www.componently.com/
 * [awesome-c](https://github.com/aleksandar-todorovic/awesome-c) by @aleksandar-todorovic – Continuing the development of awesome-c on GitHub
 * [awesome-c](https://github.com/kozross/awesome-c) by @kozross – C frameworks, libraries, resources etc.
   - [mirror](https://notabug.org/koz.ross/awesome-c)


### PR DESCRIPTION
https://github.com/componently-com/awesome-building-blocks-for-web-apps

I'm puzzled by the change in the license line - I edited via the browser and the change wasn't present before making the commit (tried twice)... I also don't think there's an actual change, unless it's some whitespace?