### PR TITLE
Add awesome-node-esm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,6 +1007,7 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
 * [awesome-nlp](https://github.com/keon/awesome-nlp) – Natural Language Processing.
 * [awesome-no-login-web-apps](https://github.com/aviaryan/awesome-no-login-web-apps) – Web apps that work without login
 * [awesome-nodejs](https://github.com/sindresorhus/awesome-nodejs) by @sindresorhus
+* [awesome-node-esm](https://github.com/talentlessguy/awesome-node-esm) - Node.js Native ESM modules and resources
 * [awesome-non-financial-blockchain](https://github.com/machinomy/awesome-non-financial-blockchain) – Non-financial applications of blockchain
 * [awesome-nosql-guides](https://github.com/erictleung/awesome-nosql-guides) – NoSQL databases
   - https://erictleung.com/awesome-nosql-guides/

--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,7 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
 * [awesome-nlp](https://github.com/keon/awesome-nlp) – Natural Language Processing.
 * [awesome-no-login-web-apps](https://github.com/aviaryan/awesome-no-login-web-apps) – Web apps that work without login
 * [awesome-nodejs](https://github.com/sindresorhus/awesome-nodejs) by @sindresorhus
-* [awesome-node-esm](https://github.com/talentlessguy/awesome-node-esm) - Node.js Native ESM modules and resources
+* [awesome-node-esm](https://github.com/talentlessguy/awesome-node-esm) - ES modules for Node.js
 * [awesome-non-financial-blockchain](https://github.com/machinomy/awesome-non-financial-blockchain) – Non-financial applications of blockchain
 * [awesome-nosql-guides](https://github.com/erictleung/awesome-nosql-guides) – NoSQL databases
   - https://erictleung.com/awesome-nosql-guides/


### PR DESCRIPTION
**Repo link**: https://github.com/talentlessguy/awesome-node-esm

**Description**: This list is a collection of Node.js libraries that support ESM out of the box. Currently, majority of Node.js libraries are CommonJS only and for that reason named imports aren't supported. This list provides libraries that either have dual target or they target Node ESM at once, meaning that you can safely use named imports with them without any transpiler like Babel.